### PR TITLE
fix typo yolov6

### DIFF
--- a/partinet/__init__.py
+++ b/partinet/__init__.py
@@ -1,9 +1,9 @@
 import click
 import sys, os
 
-__version__ = "0.1.0"
+__version__ = "0.1.1"
 
-DYNAMICDET_AVAILABLE_MODELS = ["yolov7", "yolov7x", "yolov7-w6", "yolov7-e6", "yolov7-d6", "yolov6-e6e"]
+DYNAMICDET_AVAILABLE_MODELS = ["yolov7", "yolov7x", "yolov7-w6", "yolov7-e6", "yolov7-d6", "yolov7-e6e"]
 
 def print_params(params: dict) -> None:
     """


### PR DESCRIPTION
Made a typo when defining the available backbone detectors. This fixes that typo.