### PR TITLE
Maximal detection

### DIFF
--- a/partinet/DynamicDet/models/yolo.py
+++ b/partinet/DynamicDet/models/yolo.py
@@ -240,11 +240,12 @@ class Model(nn.Module):
                 self.get_score = False
             if self.get_score:
                 return score
-        print(f"This micrograph has difficulty score {score} for threshold {self.dy_thres}")
+        print(f"This micrograph has difficulty score {score[:, 0][0]} for threshold {self.dy_thres}\n")
         need_second = self.training or (not self.dynamic) or score[:, 0] < self.dy_thres
         need_first_head = self.training or (self.dynamic and score[:, 0] >= self.dy_thres)
 
         if need_second:
+            print(f"This micrograph has used both detectors\n")
             for m in self.model_b2:
                 if m.f == 'input':
                     x = input_x
@@ -267,6 +268,7 @@ class Model(nn.Module):
                 y.append(x if m.i in self.save_b2 else None)  # save output
 
         if need_first_head:
+            print(f"This micrograph has used only one detector\n")
             for m in self.model_h:
                 if m.f != -1:  # if not from previous layer
                     x = y[m.f] if isinstance(m.f, int) else [x if j == -1 else y[j] for j in m.f]  # from earlier layers

--- a/partinet/DynamicDet/utils/general.py
+++ b/partinet/DynamicDet/utils/general.py
@@ -613,7 +613,7 @@ def non_max_suppression(prediction, conf_thres=0.25, iou_thres=0.45, classes=Non
 
     # Settings
     min_wh, max_wh = 2, 4096  # (pixels) minimum and maximum box width and height
-    max_det = 1000  # maximum number of detections per image
+    max_det = 30000  # maximum number of detections per image
     max_nms = 30000  # maximum number of boxes into torchvision.ops.nms()
     time_limit = 10.0  # seconds to quit after
     redundant = True  # require redundant detections

--- a/partinet/DynamicDet/utils/plots.py
+++ b/partinet/DynamicDet/utils/plots.py
@@ -34,7 +34,7 @@ def color_list():
     return [hex2rgb(h) for h in matplotlib.colors.TABLEAU_COLORS.values()]  # or BASE_ (8), CSS4_ (148), XKCD_ (949)
 
 
-def plot_one_box(x, img, color=None, label=None, line_thickness=3):
+def plot_one_box(x, img, color=None, label=None, line_thickness=6):
     # Plots one bounding box on image img
     tl = line_thickness or round(0.002 * (img.shape[0] + img.shape[1]) / 2) + 1  # line/font thickness
     color = color or [random.randint(0, 255) for _ in range(3)]


### PR DESCRIPTION
NMS post-processing was capping maximum number of detections per micrograph to 300. Increased to maximum value that can be loaded into Torch.nms module (30,000). Qualitative increase in recall.

Added print statements to log adaptive router behaviour. Can be removed on public release.