### PR TITLE
Change base URL for Docusaurus configuration

### DIFF
--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -15,7 +15,7 @@ const config: Config = {
   },
 
   url: 'https://wehi-researchcomputing.github.io',
-  baseUrl: '/',
+  baseUrl: '/PartiNet/',
   organizationName: 'WEHI-ResearchComputing',
   projectName: 'PartiNet',
   deploymentBranch: 'gh-pages',


### PR DESCRIPTION
BaseURL on local build is '/' but needs to be updated to '/PartiNet/' on GitHub Pages deployment